### PR TITLE
replace throwing error with warnings for backwards compatibility

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+integrationTests
+docs
+flow-typed
+benchmark
+.github
+.prettierrc
+.nycrc.yml
+.prettierignore
+codecov.yml
+cspell.json
+.eslintignore
+.eslint.yml

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "15.8.0",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
-  "private": true,
   "main": "index",
   "module": "index.mjs",
   "types": "index.d.ts",
@@ -44,7 +43,8 @@
     "build:npm": "node resources/build-npm.js",
     "build:deno": "node resources/build-deno.js",
     "gitpublish:npm": "bash ./resources/gitpublish.sh npm npmDist",
-    "gitpublish:deno": "bash ./resources/gitpublish.sh deno denoDist"
+    "gitpublish:deno": "bash ./resources/gitpublish.sh deno denoDist",
+    "prepare": "npm run build:npm && cp -r ./npmDist/* . && rm -rf ./npmDist ./src ./resources"
   },
   "devDependencies": {
     "@babel/core": "7.12.10",

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -22,7 +22,7 @@ const MIN_INT = -2147483648;
 
 const green = '\x1B[32m';
 const yellow = '\x1B[33m';
-const red = '\e[1;31m';
+const red = '\x1B[31m';
 const warn = (error: string, msg: string) => {
   if (
     process.env.NODE_ENV === 'development' ||

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -22,7 +22,7 @@ const MIN_INT = -2147483648;
 
 const green = '\x1B[32m';
 const yellow = '\x1B[33m';
-const white = '\x1B[37m';
+const red = '\e[1;31m';
 const warn = (error: string, msg: string) => {
   if (
     process.env.NODE_ENV === 'development' ||
@@ -30,10 +30,10 @@ const warn = (error: string, msg: string) => {
   ) {
     // eslint-disable-next-line no-console
     console.warn(`
-${yellow}${error}${white}:
+${yellow}${error}${red}:
   ${msg}
   ⬆️  Find inline error message in preceding logs for more context.
-  Please fix in a ${green}backwardly compatible${white} way; either have it  pass in the right data type for the field or deprecate the incompatible field and provide a compatible replacement field.
+  Please fix in a ${green}backwardly compatible${red} way; either have it  pass in the right data type for the field or deprecate the incompatible field and provide a compatible replacement field.
 `);
   }
 };

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -20,6 +20,29 @@ import { GraphQLScalarType } from './definition';
 const MAX_INT = 2147483647;
 const MIN_INT = -2147483648;
 
+const green = '\x1B[32m';
+const yellow = '\x1B[33m';
+const white = '\x1B[37m';
+const warn = (error: string, msg: string) => {
+  if (
+    process.env.NODE_ENV === 'development' ||
+    process.env.NODE_ENV === 'dev'
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn(`
+${yellow}${error}${white}:
+  ${msg}
+  ⬆️  Find inline error message in preceding logs for more context.
+  Please fix in a ${green}backwardly compatible${white} way; either have it  pass in the right data type for the field or deprecate the incompatible field and provide a compatible replacement field.
+`);
+  }
+};
+
+const warnInputCoercion = (msg: string) =>
+  warn('Type coercion of client input variables is deprecated', msg);
+const warnResultCoercion = (msg: string) =>
+  warn('Type coercion of server serialized output has become more strict', msg);
+
 function serializeInt(outputValue: mixed): number {
   const coercedValue = serializeObject(outputValue);
 
@@ -47,17 +70,19 @@ function serializeInt(outputValue: mixed): number {
 }
 
 function coerceInt(inputValue: mixed): number {
+  let val = inputValue;
   if (!isInteger(inputValue)) {
-    throw new GraphQLError(
+    warnInputCoercion(
       `Int cannot represent non-integer value: ${inspect(inputValue)}`,
     );
+    val = serializeInt(inputValue);
   }
-  if (inputValue > MAX_INT || inputValue < MIN_INT) {
+  if (val > MAX_INT || val < MIN_INT) {
     throw new GraphQLError(
-      `Int cannot represent non 32-bit signed integer value: ${inputValue}`,
+      `Int cannot represent non 32-bit signed integer value: ${val}`,
     );
   }
-  return inputValue;
+  return val;
 }
 
 export const GraphQLInt = new GraphQLScalarType({
@@ -106,9 +131,10 @@ function serializeFloat(outputValue: mixed): number {
 
 function coerceFloat(inputValue: mixed): number {
   if (!isFinite(inputValue)) {
-    throw new GraphQLError(
+    warnInputCoercion(
       `Float cannot represent non numeric value: ${inspect(inputValue)}`,
     );
+    return serializeFloat(inputValue);
   }
   return inputValue;
 }
@@ -170,9 +196,10 @@ function serializeString(outputValue: mixed): string {
 
 function coerceString(inputValue: mixed): string {
   if (typeof inputValue !== 'string') {
-    throw new GraphQLError(
+    warnInputCoercion(
       `String cannot represent a non string value: ${inspect(inputValue)}`,
     );
+    return serializeString(inputValue);
   }
   return inputValue;
 }
@@ -210,9 +237,10 @@ function serializeBoolean(outputValue: mixed): boolean {
 
 function coerceBoolean(inputValue: mixed): boolean {
   if (typeof inputValue !== 'boolean') {
-    throw new GraphQLError(
+    warnInputCoercion(
       `Boolean cannot represent a non boolean value: ${inspect(inputValue)}`,
     );
+    return serializeBoolean(inputValue);
   }
   return inputValue;
 }
@@ -242,7 +270,8 @@ function serializeID(outputValue: mixed): string {
   if (isInteger(coercedValue)) {
     return String(coercedValue);
   }
-  throw new GraphQLError(`ID cannot represent value: ${inspect(outputValue)}`);
+  warnResultCoercion(`ID cannot represent value: ${inspect(outputValue)}`);
+  return String(outputValue);
 }
 
 function coerceID(inputValue: mixed): string {
@@ -252,7 +281,8 @@ function coerceID(inputValue: mixed): string {
   if (isInteger(inputValue)) {
     return inputValue.toString();
   }
-  throw new GraphQLError(`ID cannot represent value: ${inspect(inputValue)}`);
+  warnInputCoercion(`ID cannot represent value: ${inspect(inputValue)}`);
+  return serializeString(inputValue);
 }
 
 export const GraphQLID = new GraphQLScalarType({

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -22,7 +22,7 @@ const MIN_INT = -2147483648;
 
 const green = '\x1B[32m';
 const yellow = '\x1B[33m';
-const red = '\x1B[31m';
+const red = '\x1b[31m';
 const warn = (error: string, msg: string) => {
   if (
     process.env.NODE_ENV === 'development' ||
@@ -32,7 +32,7 @@ const warn = (error: string, msg: string) => {
     console.warn(`
 ${yellow}${error}${red}:
   ${msg}
-  ⬆️  Find inline error message in preceding logs for more context.
+  ⬆️ ALERT  Find inline error message in preceding logs for more context.
   Please fix in a ${green}backwardly compatible${red} way; either have it  pass in the right data type for the field or deprecate the incompatible field and provide a compatible replacement field.
 `);
   }

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -20,6 +20,7 @@ import { GraphQLScalarType } from './definition';
 const MAX_INT = 2147483647;
 const MIN_INT = -2147483648;
 
+const reset = "\x1b[0m"
 const green = '\x1B[32m';
 const yellow = '\x1B[33m';
 const red = '\x1b[31m';
@@ -32,8 +33,8 @@ const warn = (error: string, msg: string) => {
     console.warn(`
 ${yellow}${error}${red}:
   ${msg}
-  ⬆️ ALERT  Find inline error message in preceding logs for more context.
-  Please fix in a ${green}backwardly compatible${red} way; either have it  pass in the right data type for the field or deprecate the incompatible field and provide a compatible replacement field.
+  ⬆️  Find inline error message in preceding logs for more context.
+  Please fix in a ${green}backwardly compatible${red} way; either have it  pass in the right data type for the field or deprecate the incompatible field and provide a compatible replacement field.${reset}
 `);
   }
 };


### PR DESCRIPTION
This fixes the strict coercion check that throws an error if the type is not exactly the type it expects, for example `"4" !== 4` this will throw an error for fields that expect a `GraphQLInt`, so this PR instead consoles a warning in dev of the coercion check failing and corrects it rather than throwing an error. so we can fix this for some time while using an updated version of graphql.
